### PR TITLE
Mantenimimento 2023-06-26

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,6 @@
 name: build
 on:
+  workflow_dispatch:
   pull_request:
     branches: [ "master" ]
   push:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,7 +80,7 @@ jobs:
     runs-on: "ubuntu-latest"
     strategy:
       matrix:
-        php-versions: ['7.3', '7.4', '8.0', '8.1']
+        php-versions: ['7.3', '7.4', '8.0', '8.1', '8.2']
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.1'
+          php-version: '8.2'
           coverage: none
           tools: phpcs, cs2pr
         env:
@@ -38,7 +38,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.1'
+          php-version: '8.2'
           coverage: none
           tools: php-cs-fixer, cs2pr
         env:
@@ -55,7 +55,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.1'
+          php-version: '8.2'
           coverage: none
           tools: composer:v2, phpstan
           extensions: sqlite3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,7 +64,7 @@ jobs:
           fail-fast: true
       - name: Get composer cache directory
         id: composer-cache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
       - name: Cache dependencies
         uses: actions/cache@v3
         with:
@@ -96,7 +96,7 @@ jobs:
           fail-fast: true
       - name: Get composer cache directory
         id: composer-cache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
       - name: Cache dependencies
         uses: actions/cache@v3
         with:

--- a/.phive/phars.xml
+++ b/.phive/phars.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phive xmlns="https://phar.io/phive">
-  <phar name="php-cs-fixer" version="^3.8.0" installed="3.8.0" location="./tools/php-cs-fixer" copy="false"/>
-  <phar name="phpcs" version="^3.6.2" installed="3.7.0" location="./tools/phpcs" copy="false"/>
-  <phar name="phpcbf" version="^3.6.2" installed="3.7.0" location="./tools/phpcbf" copy="false"/>
-  <phar name="phpstan" version="^1.7.11" installed="1.7.14" location="./tools/phpstan" copy="false"/>
+  <phar name="php-cs-fixer" version="^3.19.2" installed="3.19.2" location="./tools/php-cs-fixer" copy="false"/>
+  <phar name="phpcs" version="^3.7.2" installed="3.7.2" location="./tools/phpcs" copy="false"/>
+  <phar name="phpcbf" version="^3.7.2" installed="3.7.2" location="./tools/phpcbf" copy="false"/>
+  <phar name="phpstan" version="^1.10.21" installed="1.10.21" location="./tools/phpstan" copy="false"/>
 </phive>

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -17,39 +17,32 @@ return (new PhpCsFixer\Config())
         '@PSR12:risky' => true,
         '@PHP71Migration:risky' => true,
         '@PHP73Migration' => true,
-        // PHP73Migration
-        'method_argument_space' => ['on_multiline' => 'ignore'],
         // symfony
         'class_attributes_separation' => true,
         'whitespace_after_comma_in_array' => true,
         'no_empty_statement' => true,
         'no_extra_blank_lines' => true,
         'function_typehint_space' => true,
-        'trailing_comma_in_multiline' => ['elements' => ['arrays', 'arguments']],
-        'new_with_braces' => true,
-        'no_blank_lines_after_class_opening' => true,
+        'trailing_comma_in_multiline' => ['after_heredoc' => true, 'elements' => ['arrays', 'arguments']],
         'no_blank_lines_after_phpdoc' => true,
         'object_operator_without_whitespace' => true,
         'binary_operator_spaces' => true,
         'phpdoc_scalar' => true,
-        'no_trailing_comma_in_singleline_array' => true,
+        'no_trailing_comma_in_singleline' => true,
         'single_quote' => true,
         'no_singleline_whitespace_before_semicolons' => true,
         'no_unused_imports' => true,
-        'no_whitespace_in_blank_line' => true,
         'yoda_style' => ['equal' => true, 'identical' => true, 'less_and_greater' => null],
         'standardize_not_equals' => true,
         'concat_space' => ['spacing' => 'one'],
         'linebreak_after_opening_tag' => true,
+        'fully_qualified_strict_types' => true,
         // symfony:risky
         'no_alias_functions' => true,
         'self_accessor' => true,
         // contrib
         'not_operator_with_successor_space' => true,
-        'blank_lines_before_namespace' => true,
-        'blank_line_after_opening_tag' => true,
-        'ordered_imports' => true,
-        'array_syntax' => ['syntax' => 'short'],
+        'ordered_imports' => ['imports_order' => ['class', 'function', 'const']], // @PSR12 sort_algorithm: none
     ])
     ->setFinder(
         PhpCsFixer\Finder::create()

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -46,7 +46,7 @@ return (new PhpCsFixer\Config())
         'self_accessor' => true,
         // contrib
         'not_operator_with_successor_space' => true,
-        'single_blank_line_before_namespace' => true,
+        'blank_lines_before_namespace' => true,
         'blank_line_after_opening_tag' => true,
         'ordered_imports' => true,
         'array_syntax' => ['syntax' => 'short'],

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contribuciones
 
-Las contribuciones son bienvenidas. Aceptamos *Pull Requests* en el [repositorio GitHub][homepage].
+Las contribuciones son bienvenidas. Aceptamos *Pull Requests* en el [repositorio GitHub][project].
 
 Este proyecto se apega al siguiente [Código de Conducta][coc].
 Al participar en este proyecto y en su comunidad, deberás seguir este código.

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2019 - 2022 PhpCfdi https://www.phpcfdi.com/
+Copyright (c) 2019 - 2023 PhpCfdi https://www.phpcfdi.com/
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ and licensed for use under the MIT License (MIT). Please see [LICENSE][] for mor
 [badge-source]: https://img.shields.io/badge/source-phpcfdi/sat--catalogos-blue?style=flat-square
 [badge-release]: https://img.shields.io/github/release/phpcfdi/sat-catalogos?style=flat-square
 [badge-license]: https://img.shields.io/github/license/phpcfdi/sat-catalogos?style=flat-square
-[badge-build]: https://img.shields.io/github/workflow/status/phpcfdi/sat-catalogos/build/master?style=flat-square
+[badge-build]: https://img.shields.io/github/actions/workflow/status/phpcfdi/sat-catalogos/build.yml?branch=master&style=flat-square
 [badge-quality]: https://img.shields.io/scrutinizer/g/phpcfdi/sat-catalogos/master?style=flat-square
 [badge-coverage]: https://img.shields.io/scrutinizer/coverage/g/phpcfdi/sat-catalogos/master?style=flat-square
 [badge-downloads]: https://img.shields.io/packagist/dt/phpcfdi/sat-catalogos?style=flat-square

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
         }
     },
     "scripts": {
-        "dev:build": ["@dev:fix-style", "@dev:test"],
+        "dev:build": ["@dev:fix-style", "@dev:tests"],
         "dev:check-style": [
             "@php tools/php-cs-fixer fix --dry-run --verbose",
             "@php tools/phpcs --colors -sp"

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -17,6 +17,8 @@ versión aunque sí su incorporación en la rama principal de trabajo, generalme
 - Se corrige la liga al proyecto del archivo `CONTRIBUTING.md`.
 - Se corrige el archivo de configuración de la herramienta `php-cs-fixer`.
 - Se corrige la insignia de construcción.
+- Se modifica el flujo de trabajo de construcción en GitHub:
+  - Se agrega PHP 8.2 a la matriz de pruebas.
 - Se actualizan las herramientas de desarrollo.
 
 ### Versión 0.3.0

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,7 @@ versión aunque sí su incorporación en la rama principal de trabajo, generalme
 ### Mantenimimento 2023-06-26
 
 - Actualizar archivo de licencia.
+- Se corrige el archivo de configuración de la herramienta `php-cs-fixer`.
 - Se corrige la insignia de construcción.
 
 ### Versión 0.3.0

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,7 @@ versión aunque sí su incorporación en la rama principal de trabajo, generalme
 ### Mantenimimento 2023-06-26
 
 - Actualizar archivo de licencia.
+- Se corrige la liga al proyecto del archivo `CONTRIBUTING.md`.
 - Se corrige el archivo de configuración de la herramienta `php-cs-fixer`.
 - Se corrige la insignia de construcción.
 - Se actualizan las herramientas de desarrollo.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -20,6 +20,7 @@ versión aunque sí su incorporación en la rama principal de trabajo, generalme
 - Se modifica el flujo de trabajo de construcción en GitHub:
   - Se agrega PHP 8.2 a la matriz de pruebas.
   - Las herramientas de desarrollo se ejecutan en PHP 8.2.
+  - Se permite ejecutar el flujo a petición.
 - Se actualizan las herramientas de desarrollo.
 
 ### Versión 0.3.0

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,7 +15,8 @@ versión aunque sí su incorporación en la rama principal de trabajo, generalme
 
 - Actualizar archivo de licencia.
 - Se corrige la liga al proyecto del archivo `CONTRIBUTING.md`.
-- Se corrige el archivo de configuración de la herramienta `php-cs-fixer`.
+- Se corrigen las reglas deprecadas de `php-cs-fixer`.
+- Se actualizan los archivos de configuración de las herramientas de corrección de estilo.
 - Se corrige la insignia de construcción.
 - Se modifica el flujo de trabajo de construcción en GitHub:
   - Se agrega PHP 8.2 a la matriz de pruebas.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -16,6 +16,7 @@ versión aunque sí su incorporación en la rama principal de trabajo, generalme
 - Actualizar archivo de licencia.
 - Se corrige el archivo de configuración de la herramienta `php-cs-fixer`.
 - Se corrige la insignia de construcción.
+- Se actualizan las herramientas de desarrollo.
 
 ### Versión 0.3.0
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -21,6 +21,7 @@ versión aunque sí su incorporación en la rama principal de trabajo, generalme
   - Se agrega PHP 8.2 a la matriz de pruebas.
   - Las herramientas de desarrollo se ejecutan en PHP 8.2.
   - Se permite ejecutar el flujo a petición.
+  - Se sustituye la directiva `::set-output` con `$GITHUB_OUTPUT`.
 - Se actualizan las herramientas de desarrollo.
 
 ### Versión 0.3.0

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,9 +11,9 @@ versión aunque sí su incorporación en la rama principal de trabajo, generalme
 
 ## Listado de cambios
 
-### UNRELEASED
+### Mantenimimento 2023-06-26
 
-No hay cambios sin liberación.
+- Actualizar archivo de licencia.
 
 ### Versión 0.3.0
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -19,6 +19,7 @@ versión aunque sí su incorporación en la rama principal de trabajo, generalme
 - Se corrige la insignia de construcción.
 - Se modifica el flujo de trabajo de construcción en GitHub:
   - Se agrega PHP 8.2 a la matriz de pruebas.
+  - Las herramientas de desarrollo se ejecutan en PHP 8.2.
 - Se actualizan las herramientas de desarrollo.
 
 ### Versión 0.3.0

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,7 @@ versión aunque sí su incorporación en la rama principal de trabajo, generalme
 ### Mantenimimento 2023-06-26
 
 - Actualizar archivo de licencia.
+- Se corrige la insignia de construcción.
 
 ### Versión 0.3.0
 

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <ruleset name="EngineWorks">
     <description>The EngineWorks (PSR-12 based) coding standard.</description>
 


### PR DESCRIPTION
- Actualizar archivo de licencia.
- Se corrige la liga al proyecto del archivo `CONTRIBUTING.md`.
- Se corrigen las reglas deprecadas de `php-cs-fixer`.
- Se actualizan los archivos de configuración de las herramientas de corrección de estilo.
- Se corrige la insignia de construcción.
- Se modifica el flujo de trabajo de construcción en GitHub:
  - Se agrega PHP 8.2 a la matriz de pruebas.
  - Las herramientas de desarrollo se ejecutan en PHP 8.2.
  - Se permite ejecutar el flujo a petición.
  - Se sustituye la directiva `::set-output` con `$GITHUB_OUTPUT`.
- Se actualizan las herramientas de desarrollo.