### PR TITLE
Corregir codigos postales estímulo frontera y mantenimiento (Versión 0.3.1)

### DIFF
--- a/.phive/phars.xml
+++ b/.phive/phars.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phive xmlns="https://phar.io/phive">
-  <phar name="php-cs-fixer" version="^3.19.2" installed="3.19.2" location="./tools/php-cs-fixer" copy="false"/>
+  <phar name="php-cs-fixer" version="^3.20.0" installed="3.20.0" location="./tools/php-cs-fixer" copy="false"/>
   <phar name="phpcs" version="^3.7.2" installed="3.7.2" location="./tools/phpcs" copy="false"/>
   <phar name="phpcbf" version="^3.7.2" installed="3.7.2" location="./tools/phpcbf" copy="false"/>
-  <phar name="phpstan" version="^1.10.21" installed="1.10.21" location="./tools/phpstan" copy="false"/>
+  <phar name="phpstan" version="^1.10.23" installed="1.10.23" location="./tools/phpstan" copy="false"/>
 </phive>

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Usted no debería modificar la base de datos, esto equivale a modificar el códi
 
 Esta librería no contiene métodos para manipular la base de datos.
 La base de datos es simplemente un repositorio de datos de lectura.
-Bien podría tratarse de datos en formato JSON, sin embargo al desarrollar la librería
+Bien podría tratarse de datos en formato JSON, sin embargo, al desarrollar la librería
 no encontramos una forma ágil y de pocos recursos para leer en un formato diferente.
 
 ## Versionado de la librería

--- a/README.md
+++ b/README.md
@@ -8,9 +8,12 @@
 [![Coverage Status][badge-coverage]][coverage]
 [![Total Downloads][badge-downloads]][downloads]
 
-> Catálogos de SAT para CFDI 3.3
+> Catálogos de SAT para CFDI 3.3, CFDI 4.0 y Nómina 1.2.
 
-Esta librería permite usar los catálogos del SAT para CFDI version 3.3.
+Esta librería permite usar los catálogos del SAT para:
+  - CFDI 3.3.
+  - CFDI 4.0.
+  - Nómina 1.2.
 
 Vea la [Información general de catálogos](docs/Catalogos.md) para mayor información.
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,7 +6,7 @@ Usamos [Versionado Semántico 2.0.0](SEMVER.md) por lo que puedes usar esta libr
 
 ## Cambios no liberados en una versión
 
-Pueden aparecer cambios no liberados que se integran a la rama principal pero no ameritan una nueva liberación de
+Pueden aparecer cambios no liberados que se integran a la rama principal, pero no ameritan una nueva liberación de
 versión aunque sí su incorporación en la rama principal de trabajo, generalmente se tratan de cambios en el desarrollo.
 
 ## Listado de cambios

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -22,6 +22,7 @@ Los siguientes cambios son de mantenimiento:
 
 - Se actualiza el archivo de creación de base de datos para pruebas.
 - Se actualiza la herramienta para crear el archivo de creación de base de datos para pruebas.
+- Se actualizan las herramientas de desarrollo
 
 ### Mantenimimento 2023-06-26
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,11 @@ versión aunque sí su incorporación en la rama principal de trabajo, generalme
 - Se agrega el método `hasEstímuloFrontera(): bool` de `CFDI\CodigoPostal` y `CFDI40\CodigoPostal` 
   que retorna si el código postal tiene estímulo fronterizo.
 
+Los siguientes cambios son de mantenimiento:
+
+- Se actualiza el archivo de creación de base de datos para pruebas.
+- Se actualiza la herramienta para crear el archivo de creación de base de datos para pruebas.
+
 ### Mantenimimento 2023-06-26
 
 - Actualizar archivo de licencia.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,11 +11,11 @@ versión aunque sí su incorporación en la rama principal de trabajo, generalme
 
 ## Listado de cambios
 
-### Version 0.3.1 2023-06-04
+### Versión 0.3.1 2023-06-04
 
-- Se corrige la propiedad `estimuloFrontera` de `CFDI\CodigoPostal` y `CFDI40\CodigoPostal`, 
+- Se corrige la propiedad `CFDI\CodigoPostal::estimuloFrontera()` y `CFDI40\CodigoPostal::estimuloFrontera()`, 
   anteriormente era un boleano y ahora es un entero.
-- Se agrega el método `hasEstímuloFrontera(): bool` de `CFDI\CodigoPostal` y `CFDI40\CodigoPostal` 
+- Se agrega el método `CFDI\CodigoPostal::hasEstímuloFrontera()` y `CFDI40\CodigoPostal::hasEstímuloFrontera()`,  
   que retorna si el código postal tiene estímulo fronterizo.
 
 Los siguientes cambios son de mantenimiento:
@@ -24,7 +24,7 @@ Los siguientes cambios son de mantenimiento:
 - Se actualiza la herramienta para crear el archivo de creación de base de datos para pruebas.
 - Se actualizan las herramientas de desarrollo
 
-### Mantenimimento 2023-06-26
+Los siguientes cambios de mantenimiento se aplicaron en 2023-06-26:
 
 - Actualizar archivo de licencia.
 - Se corrige la liga al proyecto del archivo `CONTRIBUTING.md`.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,13 @@ versión aunque sí su incorporación en la rama principal de trabajo, generalme
 
 ## Listado de cambios
 
+### Version 0.3.1 2023-06-04
+
+- Se corrige la propiedad `estimuloFrontera` de `CFDI\CodigoPostal` y `CFDI40\CodigoPostal`, 
+  anteriormente era un boleano y ahora es un entero.
+- Se agrega el método `hasEstímuloFrontera(): bool` de `CFDI\CodigoPostal` y `CFDI40\CodigoPostal` 
+  que retorna si el código postal tiene estímulo fronterizo.
+
 ### Mantenimimento 2023-06-26
 
 - Actualizar archivo de licencia.

--- a/docs/SEMVER.md
+++ b/docs/SEMVER.md
@@ -26,7 +26,7 @@ Esto significa que:
 ## Versiones 0.x.y no rompe compatibilidad
 
 Las versiones que inician con cero, por ejemplo `0.y.z`, no se ajustan a las reglas de versionado.
-Se considera que estas versiones son previas a la madurez del proyecto y por lo tanto
+Se considera que estas versiones son previas a la madurez del proyecto y, por lo tanto,
 introducen cambios sin previo aviso.
 
 ## `@internal` no rompe compatibilidad

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1,4 +1,4 @@
-# phpcfdi/sat-catalogos lista de tareas pendientes
+# `phpcfdi/sat-catalogos` lista de tareas pendientes
 
 ## Catálogos disponibles aún no implementados
 

--- a/src/CFDI/CodigoPostal.php
+++ b/src/CFDI/CodigoPostal.php
@@ -19,7 +19,7 @@ class CodigoPostal extends AbstractEntryIdentifiable implements EntryIdentifiabl
     /** @var string */
     private $localidad;
 
-    /** @var bool */
+    /** @var int */
     private $estimuloFrontera;
 
     /** @var HusoHorario */
@@ -30,7 +30,7 @@ class CodigoPostal extends AbstractEntryIdentifiable implements EntryIdentifiabl
         string $estado,
         string $municipio,
         string $localidad,
-        bool $estimuloFrontera,
+        int $estimuloFrontera,
         HusoHorario $husoHorario,
         int $vigenteDesde,
         int $vigenteHasta
@@ -61,9 +61,14 @@ class CodigoPostal extends AbstractEntryIdentifiable implements EntryIdentifiabl
         return $this->localidad;
     }
 
-    public function estimuloFrontera(): bool
+    public function estimuloFrontera(): int
     {
         return $this->estimuloFrontera;
+    }
+
+    public function hasEstimuloFrontera(): bool
+    {
+        return 0 !== $this->estimuloFrontera;
     }
 
     public function husoHorario(): HusoHorario

--- a/src/CFDI/CodigosPostales.php
+++ b/src/CFDI/CodigosPostales.php
@@ -31,7 +31,7 @@ class CodigosPostales extends AbstractCatalogIdentifiable
             $values->string('estado'),
             $values->string('municipio'),
             $values->string('localidad'),
-            $values->bool('estimulo_frontera'),
+            $values->int('estimulo_frontera'),
             new HusoHorario(
                 $values->string('huso_descripcion'),
                 new HusoHorarioEstacion(

--- a/src/CFDI40/CodigoPostal.php
+++ b/src/CFDI40/CodigoPostal.php
@@ -19,7 +19,7 @@ class CodigoPostal extends AbstractEntryIdentifiable implements EntryIdentifiabl
     /** @var string */
     private $localidad;
 
-    /** @var bool */
+    /** @var int */
     private $estimuloFrontera;
 
     /** @var HusoHorario */
@@ -30,7 +30,7 @@ class CodigoPostal extends AbstractEntryIdentifiable implements EntryIdentifiabl
         string $estado,
         string $municipio,
         string $localidad,
-        bool $estimuloFrontera,
+        int $estimuloFrontera,
         HusoHorario $husoHorario,
         int $vigenteDesde,
         int $vigenteHasta
@@ -61,9 +61,14 @@ class CodigoPostal extends AbstractEntryIdentifiable implements EntryIdentifiabl
         return $this->localidad;
     }
 
-    public function estimuloFrontera(): bool
+    public function estimuloFrontera(): int
     {
         return $this->estimuloFrontera;
+    }
+
+    public function hasEstimuloFrontera(): bool
+    {
+        return 0 !== $this->estimuloFrontera;
     }
 
     public function husoHorario(): HusoHorario

--- a/src/CFDI40/CodigosPostales.php
+++ b/src/CFDI40/CodigosPostales.php
@@ -31,7 +31,7 @@ class CodigosPostales extends AbstractCatalogIdentifiable
             $values->string('estado'),
             $values->string('municipio'),
             $values->string('localidad'),
-            $values->bool('estimulo_frontera'),
+            $values->int('estimulo_frontera'),
             new HusoHorario(
                 $values->string('huso_descripcion'),
                 new HusoHorarioEstacion(

--- a/tests/Unit/CFDI/CodigoPostalTest.php
+++ b/tests/Unit/CFDI/CodigoPostalTest.php
@@ -29,7 +29,7 @@ final class CodigoPostalTest extends TestCase
         $estado = 'MEX';
         $municipio = '051';
         $localidad = '';
-        $estimuloFrontera = false;
+        $estimuloFrontera = 0;
         $husoHorario = $this->createHusoHorario();
         $vigenteDesde = 0;
         $vigenteHasta = strtotime('2019-01-13');
@@ -61,18 +61,19 @@ final class CodigoPostalTest extends TestCase
     {
         $this->expectException(SatCatalogosLogicException::class);
         $this->expectExceptionMessage('El campo estado no puede ser una cadena de caracteres vacía');
-        new CodigoPostal('52000', '', '', '', false, $this->createHusoHorario(), 0, 0);
+        new CodigoPostal('52000', '', '', '', 0, $this->createHusoHorario(), 0, 0);
     }
 
     /**
-     * @param bool $estimuloFrontera
-     * @testWith [true]
-     *           [false]
+     * @testWith [0, false]
+     *           [1, true]
+     *           [2, true]
      */
-    public function testPropertyEstimuloFrontera(bool $estimuloFrontera): void
+    public function testPropertyEstimuloFrontera(int $estimuloFrontera, bool $hasEstimuloFrontera): void
     {
         $husoHorario = $this->createHusoHorario();
         $codigoPostal = new CodigoPostal('52000', 'MEX', '051', '', $estimuloFrontera, $husoHorario, 0, 0);
         $this->assertSame($estimuloFrontera, $codigoPostal->estimuloFrontera());
+        $this->assertSame($hasEstimuloFrontera, $codigoPostal->hasEstimuloFrontera());
     }
 }

--- a/tests/Unit/CFDI40/CodigoPostalTest.php
+++ b/tests/Unit/CFDI40/CodigoPostalTest.php
@@ -29,7 +29,7 @@ final class CodigoPostalTest extends TestCase
         $estado = 'MEX';
         $municipio = '051';
         $localidad = '';
-        $estimuloFrontera = false;
+        $estimuloFrontera = 0;
         $husoHorario = $this->createHusoHorario();
         $vigenteDesde = 0;
         $vigenteHasta = strtotime('2019-01-13');
@@ -61,18 +61,19 @@ final class CodigoPostalTest extends TestCase
     {
         $this->expectException(SatCatalogosLogicException::class);
         $this->expectExceptionMessage('El campo estado no puede ser una cadena de caracteres vacía');
-        new CodigoPostal('52000', '', '', '', false, $this->createHusoHorario(), 0, 0);
+        new CodigoPostal('52000', '', '', '', 0, $this->createHusoHorario(), 0, 0);
     }
 
     /**
-     * @param bool $estimuloFrontera
-     * @testWith [true]
-     *           [false]
+     * @testWith [0, false]
+     *           [1, true]
+     *           [2, true]
      */
-    public function testPropertyEstimuloFrontera(bool $estimuloFrontera): void
+    public function testPropertyEstimuloFrontera(int $estimuloFrontera, bool $hasEstimuloFrontera): void
     {
         $husoHorario = $this->createHusoHorario();
         $codigoPostal = new CodigoPostal('52000', 'MEX', '051', '', $estimuloFrontera, $husoHorario, 0, 0);
         $this->assertSame($estimuloFrontera, $codigoPostal->estimuloFrontera());
+        $this->assertSame($hasEstimuloFrontera, $codigoPostal->hasEstimuloFrontera());
     }
 }

--- a/tests/database-seed.sql
+++ b/tests/database-seed.sql
@@ -114,17 +114,17 @@ CREATE TABLE IF NOT EXISTS "ccp_20_configuraciones_maritimas"(
   "vigencia_hasta" text not null,
   PRIMARY KEY("id")
 );
-CREATE TABLE IF NOT EXISTS "ccp_20_contenedores_maritimos"(
-  "id" text not null,
-  "texto" text not null,
-  "vigencia_desde" text not null,
-  "vigencia_hasta" text not null,
-  PRIMARY KEY("id")
-);
 CREATE TABLE IF NOT EXISTS "ccp_20_contenedores"(
   "id" text not null,
   "texto" text not null,
   "descripcion" text not null,
+  "vigencia_desde" text not null,
+  "vigencia_hasta" text not null,
+  PRIMARY KEY("id")
+);
+CREATE TABLE IF NOT EXISTS "ccp_20_contenedores_maritimos"(
+  "id" text not null,
+  "texto" text not null,
   "vigencia_desde" text not null,
   "vigencia_hasta" text not null,
   PRIMARY KEY("id")
@@ -738,6 +738,79 @@ CREATE TABLE IF NOT EXISTS "nomina_tipos_regimenes"(
 CREATE TABLE IF NOT EXISTS "pagos_tipos_cadena_pago"(
   "id" text not null,
   "texto" text not null,
+  PRIMARY KEY("id")
+);
+CREATE TABLE IF NOT EXISTS "ret_20_claves_retencion"(
+  "id" text not null,
+  "texto" text not null,
+  "nombre_complemento" text not null,
+  "vigencia_desde" text not null,
+  "vigencia_hasta" text not null,
+  PRIMARY KEY("id")
+);
+CREATE TABLE IF NOT EXISTS "ret_20_ejercicios"(
+  "id" int not null,
+  "texto" text not null,
+  "vigencia_desde" text not null,
+  "vigencia_hasta" text not null,
+  PRIMARY KEY("id")
+);
+CREATE TABLE IF NOT EXISTS "ret_20_entidades_federativas"(
+  "id" text not null,
+  "texto" text not null,
+  "vigencia_desde" text not null,
+  "vigencia_hasta" text not null,
+  PRIMARY KEY("id")
+);
+CREATE TABLE IF NOT EXISTS "ret_20_paises"(
+  "id" text not null,
+  "texto" text not null,
+  "vigencia_desde" text not null,
+  "vigencia_hasta" text not null,
+  PRIMARY KEY("id")
+);
+CREATE TABLE IF NOT EXISTS "ret_20_periodicidades"(
+  "id" text not null,
+  "texto" text not null,
+  "nombre_complemento" text not null,
+  "vigencia_desde" text not null,
+  "vigencia_hasta" text not null,
+  PRIMARY KEY("id")
+);
+CREATE TABLE IF NOT EXISTS "ret_20_periodos"(
+  "id" text not null,
+  "texto" text not null,
+  "vigencia_desde" text not null,
+  "vigencia_hasta" text not null,
+  PRIMARY KEY("id")
+);
+CREATE TABLE IF NOT EXISTS "ret_20_tipos_contribuyentes"(
+  "id" text not null,
+  "texto" text not null,
+  "vigencia_desde" text not null,
+  "vigencia_hasta" text not null,
+  PRIMARY KEY("id")
+);
+CREATE TABLE IF NOT EXISTS "ret_20_tipos_dividendos_utilidades"(
+  "id" text not null,
+  "texto" text not null,
+  "vigencia_desde" text not null,
+  "vigencia_hasta" text not null,
+  PRIMARY KEY("id")
+);
+CREATE TABLE IF NOT EXISTS "ret_20_tipos_impuestos"(
+  "id" text not null,
+  "texto" text not null,
+  "vigencia_desde" text not null,
+  "vigencia_hasta" text not null,
+  PRIMARY KEY("id")
+);
+CREATE TABLE IF NOT EXISTS "ret_20_tipos_pago_retencion"(
+  "id" text not null,
+  "texto" text not null,
+  "tipo_impuesto" text not null,
+  "vigencia_desde" text not null,
+  "vigencia_hasta" text not null,
   PRIMARY KEY("id")
 );
 BEGIN;

--- a/tests/database-seed.sql
+++ b/tests/database-seed.sql
@@ -743,7 +743,7 @@ CREATE TABLE IF NOT EXISTS "pagos_tipos_cadena_pago"(
 BEGIN;
 INSERT INTO cfdi_aduanas VALUES('24','NUEVO LAREDO, NUEVO LAREDO, TAMAULIPAS.','2017-01-01','');
 INSERT INTO cfdi_claves_unidades VALUES('MTK','Metro cuadrado','Es la unidad básica de superficie en el Sistema Internacional de Unidades. Si a esta unidad se antepone un prefijo del Sistema Internacional se crea un múltiplo o submúltiplo de esta.','','2017-01-01','','m²');
-INSERT INTO cfdi_codigos_postales VALUES('52000','MEX','051','','','2019-01-07','','Tiempo del Centro','Abril','Primer domingo','02:00','-5','Octubre','Último domingo','02:00','-6');
+INSERT INTO cfdi_codigos_postales VALUES('52000','MEX','051','',0,'2019-01-07','','Tiempo del Centro','','','','-6','','','','-6');
 INSERT INTO cfdi_formas_pago VALUES('03','Transferencia electrónica de fondos',1,'',1,1,'[0-9]{10}|[0-9]{16}|[0-9]{18}',1,1,'[0-9]{10}|[0-9]{18}',1,1,'2017-01-01','');
 INSERT INTO cfdi_impuestos VALUES('002','IVA',1,1,'Federal','');
 INSERT INTO cfdi_metodos_pago VALUES('PUE','Pago en una sola exhibición','2017-01-01','');
@@ -784,7 +784,7 @@ INSERT INTO cfdi_40_colonias VALUES('0002','86000','Villahermosa Centro');
 INSERT INTO cfdi_40_colonias VALUES('0009','86008','Secretaria de La Reforma Agraria');
 INSERT INTO cfdi_40_colonias VALUES('1477','86000','Centro Delegacional 6');
 INSERT INTO cfdi_40_claves_unidades VALUES('MTK','Metro cuadrado','Es la unidad básica de superficie en el Sistema Internacional de Unidades. Si a esta unidad se antepone un prefijo del Sistema Internacional se crea un múltiplo o submúltiplo de esta.','','2022-01-01','','m²');
-INSERT INTO cfdi_40_codigos_postales VALUES('52000','MEX','051','','','2022-01-01','','Tiempo del Centro','Abril','Primer domingo','02:00','-5','Octubre','Último domingo','02:00','-6');
+INSERT INTO cfdi_40_codigos_postales VALUES('52000','MEX','051','',0,'2019-01-07','','Tiempo del Centro','','','','-6','','','','-6');
 INSERT INTO cfdi_40_estados VALUES('MEX','MEX','Estado de México','2022-01-01','');
 INSERT INTO cfdi_40_estados VALUES('MIC','MEX','Michoacán','2022-01-01','');
 INSERT INTO cfdi_40_estados VALUES('MOR','MEX','Morelos','2022-01-01','');
@@ -828,6 +828,7 @@ INSERT INTO cfdi_40_numeros_pedimento_aduana VALUES('43','3420',2018,999999,'201
 INSERT INTO cfdi_40_objetos_impuestos VALUES('01','No objeto de impuesto.','2022-01-01','');
 INSERT INTO cfdi_40_objetos_impuestos VALUES('02','Sí objeto de impuesto.','2022-01-01','');
 INSERT INTO cfdi_40_objetos_impuestos VALUES('03','Sí objeto del impuesto y no obligado al desglose.','2022-01-01','');
+INSERT INTO cfdi_40_objetos_impuestos VALUES('04','Sí objeto del impuesto y no causa impuesto.','2022-10-07','');
 INSERT INTO cfdi_40_paises VALUES('CHL','Chile','','','','');
 INSERT INTO cfdi_40_paises VALUES('MEX','México','[0-9]{5}','[A-Z&Ñ]{3,4}[0-9]{2}(0[1-9]|1[012])(0[1-9]|[12][0-9]|3[01])[A-Z0-9]{2}[0\n-9A]','Lista del SAT','TLCAN');
 INSERT INTO cfdi_40_paises VALUES('USA','Estados Unidos (los)','[0-9]{5}(-[0-9]{4})?','[0-9]{9}','','TLCAN');

--- a/tests/database-to-seed.bash
+++ b/tests/database-to-seed.bash
@@ -24,9 +24,13 @@ function grep_insert_table_values()
 DB="$1"
 DUMPFILE="$(mktemp)"
 
-sqlite3 $DB ".schema --indent"
-sqlite3 $DB ".dump" > "$DUMPFILE"
+TABLES=( $(sqlite3 $DB "SELECT name FROM sqlite_schema WHERE type ='table' AND name NOT LIKE 'sqlite_%' ORDER BY name;") )
+for TABLE in "${TABLES[@]}"; do
+    sqlite3 $DB ".schema --indent $TABLE"
+done
 
+
+sqlite3 $DB ".dump" > "$DUMPFILE"
 echo "BEGIN;"
 grep_insert_table_values cfdi_aduanas "'24'"
 grep_insert_table_values cfdi_claves_unidades "'MTK'"


### PR DESCRIPTION
- Se corrige la propiedad `CFDI\CodigoPostal::estimuloFrontera()` y `CFDI40\CodigoPostal::estimuloFrontera()`, anteriormente era un boleano y ahora es un entero.
- Se agrega el método `CFDI\CodigoPostal::hasEstímuloFrontera()` y `CFDI40\CodigoPostal::hasEstímuloFrontera()`,  que retorna si el código postal tiene estímulo fronterizo.

Los siguientes cambios son de mantenimiento:

- Se actualiza el archivo de creación de base de datos para pruebas.
- Se actualiza la herramienta para crear el archivo de creación de base de datos para pruebas.
- Se actualizan las herramientas de desarrollo

